### PR TITLE
Disable attestation for forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
         run: pnpm package:${{ matrix.target }}
 
       - name: Generate artifact attestation
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: ${{ matrix.build-output }}


### PR DESCRIPTION
This should avoid running into the error:
```
Error message: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
```