### PR TITLE
Add env-driven OTel driver tracing, fix standalone build, and doc/tooling for support diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,18 @@ docker run --name gizmosql \
 ```
 
 Then connect GizmoSQL UI using:
-- Host: `localhost`
+- Host: `127.0.0.1`
 - Port: `31337`
 - Username: `gizmosql_user`
 - Password: `gizmosql_password`
 - Use TLS: enabled
 - Skip TLS Verify: enabled (for self-signed certificate)
+
+> **Use `127.0.0.1`, not `localhost`.** On this machine `localhost` resolves
+> to both `::1` and `127.0.0.1`; under Docker Desktop's loopback
+> port-forwarding, connecting via the IPv6 address stalls for ~10 seconds
+> before the driver falls back to IPv4, adding a consistent ~10s delay to
+> every connect. `127.0.0.1` skips that entirely (single-digit ms).
 
 ## Configuration
 
@@ -126,7 +132,7 @@ Then connect GizmoSQL UI using:
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| Host | GizmoSQL server hostname or IP | localhost |
+| Host | GizmoSQL server hostname or IP | 127.0.0.1 |
 | Port | GizmoSQL server port | 31337 |
 | Username | Authentication username | (required) |
 | Password | Authentication password | (required) |
@@ -281,9 +287,10 @@ pnpm dev
 > `pnpm build && pnpm start` (the production standalone server) works too.
 
 **5. Reproduce a trace:** open `http://localhost:3000`, connect using the
-credentials from step 1 (Host `localhost`, Port `31337`, Username
-`gizmosql_user`, Password `gizmosql_password`, Use TLS enabled, Skip TLS
-Verify enabled), and run any query (e.g. `SELECT count(*) FROM orders`).
+credentials from step 1 (Host `127.0.0.1` — not `localhost`, see the note
+above — Port `31337`, Username `gizmosql_user`, Password
+`gizmosql_password`, Use TLS enabled, Skip TLS Verify enabled), and run any
+query (e.g. `SELECT count(*) FROM orders`).
 
 **6. Confirm the trace arrived** by tailing the collector's log — you should
 see `Database.Open` and `ExecuteQuery` spans appear within a few seconds of

--- a/README.md
+++ b/README.md
@@ -190,6 +190,108 @@ pnpm start
 ADBC_DRIVER_FLIGHTSQL_LOG_LEVEL=debug pnpm start
 ```
 
+### Trying It Yourself: Full Local Test Setup
+
+These steps reproduce a complete tracing setup on your own machine — a test
+GizmoSQL server, a local OTel collector to receive traces, and GizmoSQL UI
+with tracing turned on. Requires [Docker](https://www.docker.com/) and this
+repo checked out locally.
+
+**1. Start a test GizmoSQL server** (same one used in
+[Starting a GizmoSQL Server](#starting-a-gizmosql-server-optional) above):
+
+```bash
+docker run --name gizmosql \
+           --detach \
+           --rm \
+           --tty \
+           --init \
+           --publish 31337:31337 \
+           --env TLS_ENABLED="1" \
+           --env GIZMOSQL_USERNAME="gizmosql_user" \
+           --env GIZMOSQL_PASSWORD="gizmosql_password" \
+           --env PRINT_QUERIES="1" \
+           --env INIT_SQL_COMMANDS="CALL dbgen(sf=0.01);" \
+           --pull always \
+           gizmodata/gizmosql:latest
+```
+
+**2. Create a minimal OTel collector config** that just prints received
+traces to its own log:
+
+```bash
+cat > /tmp/otel-collector-config.yaml <<'EOF'
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [debug]
+EOF
+```
+
+**3. Start the collector**, mounting that config in:
+
+```bash
+docker run --name otel-collector \
+           --detach \
+           --rm \
+           --publish 4317:4317 \
+           --publish 4318:4318 \
+           --volume /tmp/otel-collector-config.yaml:/etc/otelcol/config.yaml \
+           --pull always \
+           otel/opentelemetry-collector:latest \
+           --config=/etc/otelcol/config.yaml
+```
+
+**4. Start GizmoSQL UI with tracing pointed at the collector:**
+
+```bash
+pnpm install   # first time only
+
+GIZMOSQL_OTEL_TRACES_EXPORTER=otlp \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 \
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
+pnpm dev
+```
+
+> Use `pnpm dev` here, not `pnpm build && pnpm start` — the production
+> standalone build only picks up the native driver's runtime files when
+> assembled via `pnpm package` (see [Creating Standalone
+> Executables](#creating-standalone-executables)), so a plain `pnpm start`
+> will fail to connect. `pnpm dev` runs against `node_modules` directly and
+> works out of the box.
+
+**5. Reproduce a trace:** open `http://localhost:3000`, connect using the
+credentials from step 1 (Host `localhost`, Port `31337`, Username
+`gizmosql_user`, Password `gizmosql_password`, Use TLS enabled, Skip TLS
+Verify enabled), and run any query (e.g. `SELECT count(*) FROM orders`).
+
+**6. Confirm the trace arrived** by tailing the collector's log — you should
+see `Database.Open` and `ExecuteQuery` spans appear within a few seconds of
+running the query:
+
+```bash
+docker logs -f otel-collector
+```
+
+**7. Clean up** when you're done:
+
+```bash
+docker stop gizmosql otel-collector
+```
+
 Same variables apply when running a packaged executable
 (`./dist/gizmosql-ui-macos-arm64`, etc.) — just set them before launching it.
 

--- a/README.md
+++ b/README.md
@@ -159,8 +159,19 @@ controlled entirely by environment variables set on the GizmoSQL UI process
 GIZMOSQL_OTEL_TRACES_EXPORTER=console pnpm start
 ```
 
-Run a query in the UI and you'll see JSON span output in the terminal
-GizmoSQL UI is running in.
+Run a query in the UI and you'll see raw span JSON in the terminal GizmoSQL
+UI is running in — one line per span, but noisy. Pipe it through
+`scripts/format-traces.js` for a compact one-line-per-span summary instead;
+it passes all other output through unchanged:
+
+```bash
+GIZMOSQL_OTEL_TRACES_EXPORTER=console pnpm start | node scripts/format-traces.js
+```
+
+```
+[00:11:21] FlightSQLDatabase.Open             10.29s  OK  (18cb8529)
+[00:11:32] FlightSQLStatement.ExecuteQuery      25ms  OK  (cd297969)
+```
 
 **Option 2 — send traces to an OpenTelemetry collector:**
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,60 @@ Then connect GizmoSQL UI using:
 | Variable | Description | Default |
 |----------|-------------|---------|
 | PORT | HTTP server port | 3000 |
+| GIZMOSQL_OTEL_TRACES_EXPORTER | Enables driver tracing: `none`, `otlp`, `console`, or `adbcfile` | none |
+| GIZMOSQL_OTEL_TRACES_FOLDER_PATH | Output directory for the `adbcfile` exporter | — |
+| GIZMOSQL_OTEL_TRACE_PARENT | W3C `traceparent` to join an existing distributed trace | — |
+| ADBC_DRIVER_FLIGHTSQL_LOG_LEVEL | Structured driver log level: `debug`, `info`, `warn`, `error` | — |
+| OTEL_EXPORTER_OTLP_ENDPOINT | Collector endpoint, used when `GIZMOSQL_OTEL_TRACES_EXPORTER=otlp` | — |
+| OTEL_EXPORTER_OTLP_PROTOCOL | OTLP wire protocol — use `http/protobuf` (see note below) | — |
+
+### Enabling Driver Tracing (for Support/Diagnostics)
+
+GizmoSQL UI connects through the native GizmoSQL ADBC driver, which can emit
+OpenTelemetry trace spans for every query lifecycle stage (`Database.Open`,
+`Prepare`, `ExecuteQuery`, `ExecuteUpdate`). This is off by default and is
+controlled entirely by environment variables set on the GizmoSQL UI process
+— there is nothing to configure in the browser UI.
+
+**Option 1 — print traces to the terminal (quickest way to check it works):**
+
+```bash
+GIZMOSQL_OTEL_TRACES_EXPORTER=console pnpm start
+```
+
+Run a query in the UI and you'll see JSON span output in the terminal
+GizmoSQL UI is running in.
+
+**Option 2 — send traces to an OpenTelemetry collector:**
+
+```bash
+GIZMOSQL_OTEL_TRACES_EXPORTER=otlp \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 \
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
+pnpm start
+```
+
+> **Note:** use `http/protobuf`, not `grpc`. The `grpc` protocol failed to
+> connect to a standard OTel Collector in testing; `http/protobuf` against
+> the collector's OTLP/HTTP port (`4318` by default) works reliably.
+
+**Option 3 — write traces to local files** (useful for collecting a support
+bundle without standing up a collector):
+
+```bash
+GIZMOSQL_OTEL_TRACES_EXPORTER=adbcfile \
+GIZMOSQL_OTEL_TRACES_FOLDER_PATH=/tmp/gizmosql-traces \
+pnpm start
+```
+
+**Driver debug logs**, independent of tracing, are enabled the same way:
+
+```bash
+ADBC_DRIVER_FLIGHTSQL_LOG_LEVEL=debug pnpm start
+```
+
+Same variables apply when running a packaged executable
+(`./dist/gizmosql-ui-macos-arm64`, etc.) — just set them before launching it.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -168,15 +168,18 @@ GIZMOSQL_OTEL_TRACES_EXPORTER=console pnpm start
 Run a query in the UI and you'll see raw span JSON in the terminal GizmoSQL
 UI is running in — one line per span, but noisy. Pipe it through
 `scripts/format-traces.js` for a compact one-line-per-span summary instead;
-it passes all other output through unchanged:
+it passes all other output through unchanged. Each span's `Status.Description`
+(the driver's own error text, when a query fails) is always shown, not just
+on failure:
 
 ```bash
 GIZMOSQL_OTEL_TRACES_EXPORTER=console pnpm start | node scripts/format-traces.js
 ```
 
 ```
-[00:11:21] FlightSQLDatabase.Open             10.29s  OK  (18cb8529)
-[00:11:32] FlightSQLStatement.ExecuteQuery      25ms  OK  (cd297969)
+[00:44:51] FlightSQLDatabase.Open               11ms  OK      (no description)  (16b95fe0)
+[00:44:51] FlightSQLStatement.ExecuteQuery       2ms  OK      (no description)  (21db1435)
+[00:44:51] FlightSQLStatement.ExecuteQuery       5ms  Error   Invalid Argument: [FlightSQL] Can't prepare statement: 'SELCT this is not valid sql' - Error: Parser Error: syntax error at or near "SELCT" (a8ed432c)
 ```
 
 **Option 2 — send traces to an OpenTelemetry collector:**

--- a/README.md
+++ b/README.md
@@ -266,12 +266,8 @@ OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
 pnpm dev
 ```
 
-> Use `pnpm dev` here, not `pnpm build && pnpm start` — the production
-> standalone build only picks up the native driver's runtime files when
-> assembled via `pnpm package` (see [Creating Standalone
-> Executables](#creating-standalone-executables)), so a plain `pnpm start`
-> will fail to connect. `pnpm dev` runs against `node_modules` directly and
-> works out of the box.
+> `pnpm dev` is the quickest way to try this since it skips the build step.
+> `pnpm build && pnpm start` (the production standalone server) works too.
 
 **5. Reproduce a trace:** open `http://localhost:3000`, connect using the
 credentials from step 1 (Host `localhost`, Port `31337`, Username

--- a/lib/services/gizmosql.ts
+++ b/lib/services/gizmosql.ts
@@ -22,6 +22,35 @@ interface ArrowRow {
   [key: string]: unknown;
 }
 
+/**
+ * Maps operator-set env vars onto the GizmoSQL ADBC driver's telemetry
+ * database options (adbc.telemetry.*), giving support/ops staff a way to
+ * turn on driver-level OpenTelemetry tracing for a whole deployment
+ * without a UI toggle. The OTLP endpoint itself is configured separately
+ * via the driver's own standard OTEL_EXPORTER_OTLP_* env vars, which the
+ * native driver reads directly from the process environment.
+ */
+function telemetryOptionsFromEnv(): Record<string, string> {
+  const options: Record<string, string> = {};
+
+  const exporter = process.env.GIZMOSQL_OTEL_TRACES_EXPORTER;
+  if (exporter) {
+    options['adbc.telemetry.traces_exporter'] = exporter;
+  }
+
+  const folderPath = process.env.GIZMOSQL_OTEL_TRACES_FOLDER_PATH;
+  if (folderPath) {
+    options['adbc.telemetry.traces_folder_path'] = folderPath;
+  }
+
+  const traceParent = process.env.GIZMOSQL_OTEL_TRACE_PARENT;
+  if (traceParent) {
+    options['adbc.telemetry.trace_parent'] = traceParent;
+  }
+
+  return options;
+}
+
 export class GizmoSQLService {
   private client: FlightSQLClient | null = null;
   private config: GizmoSQLConfig;
@@ -51,6 +80,7 @@ export class GizmoSQLService {
       password: this.config.password,
       plaintext: !this.config.useTls,
       tlsSkipVerify: this.config.skipTlsVerify,
+      extraOptions: telemetryOptionsFromEnv(),
     });
 
     // Explicitly connect/authenticate first so auth errors are surfaced

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build --webpack",
+    "postbuild": "node scripts/postbuild.js",
     "start": "node .next/standalone/server.js",
     "lint": "eslint .",
     "bundle": "pnpm build && node scripts/bundle.js",

--- a/patches/@gizmodata__gizmosql-client@2.0.0.patch
+++ b/patches/@gizmodata__gizmosql-client@2.0.0.patch
@@ -1,0 +1,32 @@
+diff --git a/dist/flightsql-client.js b/dist/flightsql-client.js
+index a2d7d880c307511a333e6f29999c5206ef9e549f..d3e6c4264e1169e8969dcfa551e124c629b0c74e 100644
+--- a/dist/flightsql-client.js
++++ b/dist/flightsql-client.js
+@@ -79,6 +79,9 @@ class FlightSQLClient {
+             options.username = this.config.username;
+             options.password = this.config.password;
+         }
++        if (this.config.extraOptions) {
++            Object.assign(options, this.config.extraOptions);
++        }
+         return options;
+     }
+     async connect() {
+diff --git a/dist/types.d.ts b/dist/types.d.ts
+index a9299e80c2039ffef0220f89f1cd433040626335..f2a0e7e4e97f5867ac6984c01904cf94e40b5dfc 100644
+--- a/dist/types.d.ts
++++ b/dist/types.d.ts
+@@ -8,6 +8,13 @@ export interface FlightClientConfig {
+     token?: string;
+     /** OAuth HTTP port probed by discoverOAuthUrl() (default 31339). */
+     oauthPort?: number;
++    /**
++     * Raw ADBC database options merged in verbatim (e.g.
++     * `adbc.telemetry.traces_exporter`). Applied last, after the options
++     * this client derives from the rest of the config, so entries here
++     * can override the derived ones.
++     */
++    extraOptions?: Record<string, string>;
+ }
+ export type FlightSQLClientConfig = FlightClientConfig;
+ export interface PreparedStatement {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,13 +4,16 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@gizmodata/gizmosql-client@2.0.0': 59600c83e0b67c6497486cc32714cb31b3b893f9f180a8e74e3d05d5cd0df187
+
 importers:
 
   .:
     dependencies:
       '@gizmodata/gizmosql-client':
         specifier: ^2.0.0
-        version: 2.0.0
+        version: 2.0.0(patch_hash=59600c83e0b67c6497486cc32714cb31b3b893f9f180a8e74e3d05d5cd0df187)
       '@monaco-editor/react':
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -2261,7 +2264,7 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@gizmodata/gizmosql-client@2.0.0':
+  '@gizmodata/gizmosql-client@2.0.0(patch_hash=59600c83e0b67c6497486cc32714cb31b3b893f9f180a8e74e3d05d5cd0df187)':
     dependencies:
       '@apache-arrow/adbc-driver-manager': 0.24.0(apache-arrow@21.2.0)
       apache-arrow: 21.2.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,3 +19,6 @@ allowBuilds:
 # we release and consume them same-day by design.
 minimumReleaseAgeExclude:
   - "@gizmodata/*"
+
+patchedDependencies:
+  '@gizmodata/gizmosql-client@2.0.0': patches/@gizmodata__gizmosql-client@2.0.0.patch

--- a/scripts/format-traces.js
+++ b/scripts/format-traces.js
@@ -36,9 +36,12 @@ function formatSpan(span) {
     durationMs >= 1000 ? `${(durationMs / 1000).toFixed(2)}s` : `${durationMs}ms`;
   const time = start.toLocaleTimeString('en-US', { hour12: false });
   const code = span.Status?.Code ?? 'Unknown';
-  const status =
-    code === 'Ok' ? 'OK' : `${code}${span.Status?.Description ? `: ${span.Status.Description}` : ''}`;
+  const status = code === 'Ok' ? 'OK' : code;
+  // Status.Description carries the driver's error text on failure; it's
+  // always present but empty on success, so surface it explicitly rather
+  // than silently swallowing it.
+  const description = span.Status?.Description || '(no description)';
   const traceId = (span.SpanContext?.TraceID ?? '').slice(0, 8);
 
-  return `[${time}] ${span.Name.padEnd(32)} ${duration.padStart(8)}  ${status}  (${traceId})`;
+  return `[${time}] ${span.Name.padEnd(32)} ${duration.padStart(8)}  ${status.padEnd(6)}  ${description}  (${traceId})`;
 }

--- a/scripts/format-traces.js
+++ b/scripts/format-traces.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/**
+ * Pretty-prints the GizmoSQL ADBC driver's `console` trace exporter
+ * output (one raw OTel span JSON object per line) into a compact
+ * human-readable line. Any input that isn't span JSON — i.e. normal
+ * dev-server output — passes through unchanged.
+ *
+ * Usage:
+ *   GIZMOSQL_OTEL_TRACES_EXPORTER=console pnpm dev | node scripts/format-traces.js
+ */
+const readline = require('node:readline');
+
+const rl = readline.createInterface({ input: process.stdin, terminal: false });
+
+rl.on('line', (line) => {
+  const span = tryParseSpan(line);
+  process.stdout.write((span ? formatSpan(span) : line) + '\n');
+});
+
+function tryParseSpan(line) {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith('{"Name":')) return null;
+  try {
+    const obj = JSON.parse(trimmed);
+    return obj.SpanContext && obj.StartTime && obj.EndTime ? obj : null;
+  } catch {
+    return null;
+  }
+}
+
+function formatSpan(span) {
+  const start = new Date(span.StartTime);
+  const end = new Date(span.EndTime);
+  const durationMs = end - start;
+  const duration =
+    durationMs >= 1000 ? `${(durationMs / 1000).toFixed(2)}s` : `${durationMs}ms`;
+  const time = start.toLocaleTimeString('en-US', { hour12: false });
+  const code = span.Status?.Code ?? 'Unknown';
+  const status =
+    code === 'Ok' ? 'OK' : `${code}${span.Status?.Description ? `: ${span.Status.Description}` : ''}`;
+  const traceId = (span.SpanContext?.TraceID ?? '').slice(0, 8);
+
+  return `[${time}] ${span.Name.padEnd(32)} ${duration.padStart(8)}  ${status}  (${traceId})`;
+}

--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/**
+ * Back-fills GizmoSQL ADBC driver files that Next's standalone file
+ * tracer cannot see.
+ *
+ * @gizmodata/gizmosql-client reads driver-manifest.json and the
+ * downloaded native driver library (drivers/<version>/libadbc_driver_*)
+ * via fs.readFileSync/existsSync at runtime, not require()/import — so
+ * Next's static tracer never discovers them and `.next/standalone`
+ * ships without them. Without this, `pnpm start` fails to connect to
+ * any GizmoSQL server (ENOENT on driver-manifest.json). This only
+ * matters for the plain build+start flow; `pnpm package` replaces
+ * these files anyway via its own runtime-libs.tgz mechanism
+ * (scripts/prepare-standalone.js).
+ */
+const fs = require('fs');
+const path = require('path');
+
+const rootDir = path.join(__dirname, '..');
+const standaloneDir = path.join(rootDir, '.next', 'standalone');
+
+if (!fs.existsSync(standaloneDir)) {
+  process.exit(0); // no standalone output for this build config — nothing to do
+}
+
+let sourceDir;
+try {
+  sourceDir = path.dirname(
+    require.resolve('@gizmodata/gizmosql-client/package.json', { paths: [rootDir] })
+  );
+} catch {
+  console.warn('postbuild: @gizmodata/gizmosql-client not found, skipping driver backfill.');
+  process.exit(0);
+}
+
+let destDir;
+try {
+  destDir = path.dirname(
+    require.resolve('@gizmodata/gizmosql-client/package.json', {
+      paths: [path.join(standaloneDir, 'node_modules')],
+    })
+  );
+} catch {
+  console.warn(
+    'postbuild: @gizmodata/gizmosql-client missing from .next/standalone, skipping driver backfill.'
+  );
+  process.exit(0);
+}
+
+for (const name of ['driver-manifest.json', 'drivers']) {
+  const src = path.join(sourceDir, name);
+  const dest = path.join(destDir, name);
+  if (!fs.existsSync(src)) continue;
+  fs.rmSync(dest, { recursive: true, force: true });
+  fs.cpSync(src, dest, { recursive: true });
+}
+
+console.log('postbuild: backfilled GizmoSQL ADBC driver files into .next/standalone.');


### PR DESCRIPTION
## Summary
- Expose the GizmoSQL ADBC driver's built-in OpenTelemetry tracing (`Database.Open`, `Prepare`, `ExecuteQuery`, `ExecuteUpdate`) via env vars (`GIZMOSQL_OTEL_TRACES_EXPORTER`, `_TRACES_FOLDER_PATH`, `_TRACE_PARENT`), by patching `@gizmodata/gizmosql-client` to accept an `extraOptions` passthrough (`patches/@gizmodata__gizmosql-client@2.0.0.patch`) and wiring it in `GizmoSQLService.connect()` — no UI changes, an ops-level toggle.
- Fix a pre-existing bug: `pnpm build && pnpm start` failed to connect to any GizmoSQL server (ENOENT on `driver-manifest.json`). Next's standalone file tracer can't see files the client reads dynamically via `fs` rather than `require()`/`import`. Added `scripts/postbuild.js` (wired via a `postbuild` hook) to back-fill just those two paths after every build. Confirmed the `pnpm package` pkg-based pipeline is unaffected.
- Add `scripts/format-traces.js` to pretty-print the driver's console-exporter span JSON into a compact one-line-per-span summary, including the driver's `Status.Description` (real error text on query failures) which is otherwise buried in a large raw JSON blob.
- README: plain, verified, step-by-step instructions for enabling tracing (console/OTLP/file exporters + debug logging), plus a full local reproduction walkthrough (test GizmoSQL server + OTel collector + gizmosql-ui). Also documents using `127.0.0.1` instead of `localhost` for the local Docker test server — `localhost` resolves to both `::1` and `127.0.0.1`, and under Docker Desktop's loopback port-forwarding the driver's gRPC handshake over the IPv6 path stalls ~10s before falling back to IPv4 (raw TCP connects to both are instant, confirmed via `nc`); `127.0.0.1` skips the stall entirely (~10s → single-digit ms, verified live).

## Motivation
Scoping a GizmoSQL support/diagnostics product on top of this UI's existing driver stack. Since the native driver is shared across every ADBC client language (Python, Go, R, Rust, C#, C/C++, JS), making its tracing easy to turn on and easy to read here is directly reusable for fleet-wide diagnostics, not just this app.

## Test plan
All changes verified against a live stack (Docker `gizmodata/gizmosql:latest` + `otel/opentelemetry-collector`), not just unit-level:
- [x] `tsc --noEmit` and `pnpm lint` pass
- [x] Console exporter: raw spans and formatted output verified 1:1 (no dropped spans) via a controlled curl-driven test
- [x] OTLP exporter: spans received by a real OTel collector, cross-checked against the GizmoSQL server's own query log
- [x] `pnpm build && pnpm start` (previously broken): connect + query succeed against a live server
- [x] `pnpm package:prepare` (pkg packaging pipeline): still completes cleanly, `runtime-libs.tgz` built as before
- [x] `format-traces.js`: verified against both a successful query and an intentional SQL syntax error, confirming the driver's real error text (with parser line/caret detail) surfaces correctly
- [x] `127.0.0.1` vs `localhost` latency fix: reproduced with and without TLS, then verified end-to-end through the running app (10.3s → 130ms total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)